### PR TITLE
feat: restrict handler to POST /data endpoint only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ Chunk.hashFunction = (data: Uint8Array): Uint8Array => {
             url: request.url,
         }, 'Incoming request');
         
-        if (request.url !== '/data' || request.method !== 'POST') {
+        if (request.url !== '/upload' || request.method !== 'POST') {
             response.writeHead(404, { 'Content-Type': 'application/json' });
             response.end(JSON.stringify({ error: 'Not found' }));
             return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,12 @@ Chunk.hashFunction = (data: Uint8Array): Uint8Array => {
             method: request.method,
             url: request.url,
         }, 'Incoming request');
+        
+        if (request.url !== '/data' || request.method !== 'POST') {
+            response.writeHead(404, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify({ error: 'Not found' }));
+            return;
+        }
 
         request.on('data', chunk => chunks.push(chunk))
 


### PR DESCRIPTION
This PR updates the HTTP server to only accept POST requests to the `/upload` endpoint. Any requests to other paths or using other HTTP methods will now receive a 404 Not Found response.